### PR TITLE
[liip imagine] A processor that resolve all filters for given path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
 symfony/vendor
+symfony/web/media
+symfony/composer.lock
 docker/shared/.bash_history
 dev

--- a/symfony/app/AppKernel.php
+++ b/symfony/app/AppKernel.php
@@ -18,6 +18,8 @@ class AppKernel extends Kernel
             new Enqueue\Bundle\EnqueueBundle(),
             new Enqueue\ElasticaBundle\EnqueueElasticaBundle(),
             new FOS\ElasticaBundle\FOSElasticaBundle(),
+            new \Liip\ImagineBundle\LiipImagineBundle(),
+            new \Knp\Bundle\GaufretteBundle\KnpGaufretteBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/symfony/app/config/config.yml
+++ b/symfony/app/config/config.yml
@@ -23,7 +23,6 @@ framework:
         engines: ['twig']
     default_locale:  "%locale%"
     trusted_hosts:   ~
-    trusted_proxies: ~
     session:
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id:  session.handler.native_file
@@ -92,8 +91,61 @@ fos_elastica:
                         provider: ~
                         listener: ~
                         finder: ~
+
+knp_gaufrette:
+    adapters:
+        image:
+            local: { directory: '%kernel.root_dir%/../var/images' }
+
+    filesystems:
+        image:
+            adapter: 'image'
+
+    stream_wrapper:
+        protocol: 'gaufrette'
+        filesystems: ['image']
+
+liip_imagine:
+    loaders:
+        default:
+            stream: { wrapper: 'gaufrette://image/' }
+
+    resolvers:
+        web_path:
+            web_path: ~
+
+    driver: 'imagick'
+
+    filter_sets:
+        thumbnail_223x223:
+            cache: default
+            data_loader: default
+            filters:
+                thumbnail: { size: [223, 223], mode: inset }
+
+        thumbnail_23x23:
+            cache: default
+            data_loader: default
+            filters:
+                thumbnail: { size: [223, 223], mode: inset }
+
+        thumbnail_100x100:
+            cache: default
+            data_loader: default
+            filters:
+                thumbnail: { size: [223, 223], mode: inset }
+
 services:
   app.async.say_hello_processor:
     class: 'AppBundle\Async\SayHelloProcessor'
     tags:
-        - { name: 'enqueue.client.message_processor' }
+        - { name: 'enqueue.client.processor' }
+
+  app.async.resolve_all_processor:
+    class: 'AppBundle\Async\ResolveAllProcessor'
+    arguments:
+        - '@liip_imagine.cache.manager'
+        - '@liip_imagine.filter.manager'
+        - '@liip_imagine.data.manager'
+    tags:
+        - { name: 'enqueue.client.processor' }

--- a/symfony/app/config/routing.yml
+++ b/symfony/app/config/routing.yml
@@ -1,3 +1,7 @@
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+    prefix:   /
+
 app:
     resource: "@AppBundle/Controller/"
     type:     annotation

--- a/symfony/composer.json
+++ b/symfony/composer.json
@@ -18,16 +18,20 @@
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
-        "enqueue/psr-queue": "dev-master",
-        "enqueue/enqueue": "dev-master",
-        "enqueue/stomp": "dev-master",
-        "enqueue/amqp-ext": "dev-master",
-        "enqueue/enqueue-bundle": "dev-master",
-        "enqueue/job-queue": "dev-master",
-        "enqueue/test": "dev-master",
+        "enqueue/psr-queue": "*@dev",
+        "enqueue/enqueue": "*@dev",
+        "enqueue/stomp": "*@dev",
+        "enqueue/amqp-ext": "*@dev",
+        "enqueue/enqueue-bundle": "*@dev",
+        "enqueue/job-queue": "*@dev",
+        "enqueue/test": "*@dev",
+        "enqueue/null": "*@dev",
         "friendsofsymfony/elastica-bundle": "^3",
         "enqueue/elastica-bundle": "dev-master",
-        "fzaninotto/faker": "^1.6"
+        "fzaninotto/faker": "^1.6",
+        "liip/imagine-bundle": "^1.7.4",
+        "knplabs/gaufrette": "^0.3",
+        "knplabs/knp-gaufrette-bundle": "^0.4"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
@@ -81,6 +85,10 @@
         {
             "type": "path",
             "url": "../dev/pkg/enqueue"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/null"
         },
         {
             "type": "path",

--- a/symfony/src/AppBundle/Async/ResolveAllProcessor.php
+++ b/symfony/src/AppBundle/Async/ResolveAllProcessor.php
@@ -1,0 +1,83 @@
+<?php
+namespace AppBundle\Async;
+
+use Enqueue\Client\TopicSubscriberInterface;
+use Enqueue\Consumption\QueueSubscriberInterface;
+use Enqueue\Psr\PsrContext;
+use Enqueue\Psr\PsrMessage;
+use Enqueue\Psr\PsrProcessor;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Data\DataManager;
+use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+
+class ResolveAllProcessor implements PsrProcessor, TopicSubscriberInterface, QueueSubscriberInterface
+{
+    /**
+     * @var CacheManager
+     */
+    private $cacheManager;
+
+    /**
+     * @var FilterManager
+     */
+    private $filterManager;
+
+    /**
+     * @var DataManager
+     */
+    private $dataManager;
+    /**
+     * @param CacheManager $cacheManager
+     * @param FilterManager $filterManager
+     * @param DataManager $dataManager
+     */
+    public function __construct(CacheManager $cacheManager, FilterManager $filterManager, DataManager $dataManager)
+    {
+        $this->cacheManager = $cacheManager;
+        $this->filterManager = $filterManager;
+        $this->dataManager = $dataManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(PsrMessage $psrMessage, PsrContext $psrContext)
+    {
+        $path = $psrMessage->getBody();
+        foreach ($this->filterManager->getFilterConfiguration()->all() as $filter => $config) {
+            if (false == $this->cacheManager->isStored($path, $filter)) {
+                $binary = $this->dataManager->find($filter, $path);
+                $this->cacheManager->store(
+                    $this->filterManager->applyFilter($binary, $filter),
+                    $path,
+                    $filter
+                );
+            }
+
+            $this->cacheManager->resolve($path, $filter);
+        }
+
+        return self::ACK;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedTopics()
+    {
+        return [
+            Topics::RESOLVE_ALL => [
+                'queueName' => Topics::RESOLVE_ALL,
+                'queueNameHardcoded' => true
+            ]
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedQueues()
+    {
+        return [Topics::RESOLVE_ALL];
+    }
+}

--- a/symfony/src/AppBundle/Async/Topics.php
+++ b/symfony/src/AppBundle/Async/Topics.php
@@ -6,4 +6,6 @@ class Topics
     const SAY_HELLO = 'say_hello';
 
     const DO_RPC_CALLS = 'do_rpc_calls';
+
+    const RESOLVE_ALL = 'liip_imagine_resolve_all';
 }

--- a/symfony/src/AppBundle/Controller/DefaultController.php
+++ b/symfony/src/AppBundle/Controller/DefaultController.php
@@ -2,11 +2,13 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Async\Topics;
 use Enqueue\Client\Message;
 use Enqueue\Client\ProducerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class DefaultController extends Controller
 {
@@ -30,5 +32,24 @@ class DefaultController extends Controller
         return $this->render('default/index.html.twig', [
             'base_dir' => realpath($this->getParameter('kernel.root_dir').'/..').DIRECTORY_SEPARATOR,
         ]);
+    }
+
+    /**
+     * @Route("/liip_imagine/resolve_all", name="liip_imagine_resolve_all")
+     */
+    public function liipImagineResolveAllAction(Request $request)
+    {
+        /** @var ProducerInterface $producer */
+        $producer = $this->get('enqueue.producer');
+
+        $producer->send(Topics::RESOLVE_ALL, 'kitten.jpg');
+        $producer->send(Topics::RESOLVE_ALL, 'castle.jpg');
+
+        return new Response(<<<HTML
+<p> The controller sends a message to resolve cache for two images kitten.jpg and castle.jpg.</p>
+<p> Before you run this make sure web/media folder is empty and the consumer is up and running.</p>
+<p> After you did the request there must be some messages in the queue and files in /web/media folder must appear.</p>
+HTML
+        );
     }
 }


### PR DESCRIPTION
The PR adds an example on how Enqueue could be used to process images in background. All the hard work is done by LiipImagineBundle.

You have to send an image path (in terms of LiipImagineBundle) to the topic `liip_imagine_resolve_all`. Here's how:

```php
<?php

/** @var ProducerInterface $producer */
$producer = $this->get('enqueue.producer');

$producer->send('liip_imagine_resolve_all', 'the/path/to/original/image.png');
```

Than register a processor that do the job:

```php
<?php
namespace AppBundle\Async;

use Enqueue\Consumption\QueueSubscriberInterface;
use Enqueue\Psr\PsrContext;
use Enqueue\Psr\PsrMessage;
use Enqueue\Psr\PsrProcessor;
use Liip\ImagineBundle\Imagine\Cache\CacheManager;
use Liip\ImagineBundle\Imagine\Data\DataManager;
use Liip\ImagineBundle\Imagine\Filter\FilterManager;

class ResolveAllProcessor implements PsrProcessor, QueueSubscriberInterface
{
    /**
     * @var CacheManager
     */
    private $cacheManager;

    /**
     * @var FilterManager
     */
    private $filterManager;

    /**
     * @var DataManager
     */
    private $dataManager;
    /**
     * @param CacheManager $cacheManager
     * @param FilterManager $filterManager
     * @param DataManager $dataManager
     */
    public function __construct(CacheManager $cacheManager, FilterManager $filterManager, DataManager $dataManager)
    {
        $this->cacheManager = $cacheManager;
        $this->filterManager = $filterManager;
        $this->dataManager = $dataManager;
    }

    /**
     * {@inheritdoc}
     */
    public function process(PsrMessage $psrMessage, PsrContext $psrContext)
    {
        $path = $psrMessage->getBody();
        foreach ($this->filterManager->getFilterConfiguration()->all() as $filter => $config) {
            if (false == $this->cacheManager->isStored($path, $filter)) {
                $binary = $this->dataManager->find($filter, $path);
                $this->cacheManager->store(
                    $this->filterManager->applyFilter($binary, $filter),
                    $path,
                    $filter
                );
            }

            $this->cacheManager->resolve($path, $filter);
        }

        return self::ACK;
    }

    /**
     * {@inheritdoc}
     */
    public static function getSubscribedQueues()
    {
        return ['liip_imagine_resolve_all'];
    }
}
```

and its service:

```yaml
services:
    app.async.resolve_all_processor:
        class: 'AppBundle\Async\ResolveAllProcessor'
        arguments:
            - '@liip_imagine.cache.manager'
            - '@liip_imagine.filter.manager'
            - '@liip_imagine.data.manager'
```

run the consumer:

```bash
$ bin/console enqueue:transport:consume app.async.resolve_all_processor -vv
```

That's it.
