### PR TITLE
Swiftmailer Queue spool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 symfony/vendor
 symfony/web/media
 symfony/composer.lock
+swiftmailer/composer.lock
+swiftmailer/vendor
+swiftmailer/queue
 docker/shared/.bash_history
 dev

--- a/swiftmailer/QueueSpool.php
+++ b/swiftmailer/QueueSpool.php
@@ -1,0 +1,102 @@
+<?php
+namespace Demo\Swiftmailer;
+
+use Enqueue\Psr\ExceptionInterface as PsrException;
+use Enqueue\Psr\PsrContext;
+use Swift_Mime_SimpleMessage;
+use Swift_Transport;
+
+class QueueSpool extends \Swift_ConfigurableSpool
+{
+    /**
+     * @var PsrContext
+     */
+    private $context;
+
+    /**
+     * @param PsrContext $context
+     */
+    public function __construct(PsrContext $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function queueMessage(Swift_Mime_SimpleMessage $message)
+    {
+        try {
+            $queue = $this->context->createQueue('swiftmailer_spool');
+
+            $message = $this->context->createMessage(serialize($message));
+
+            $this->context->createProducer()->send($queue, $message);
+        } catch (PsrException $e) {
+            throw new \Swift_IoException(sprintf('Unable to send message to message queue.'), null, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null)
+    {
+        $queue = $this->context->createQueue('swiftmailer_spool');
+        $consumer = $this->context->createConsumer($queue);
+
+        $isTransportStarted = false;
+
+        $failedRecipients = (array) $failedRecipients;
+        $count = 0;
+        $time = time();
+
+        while (true) {
+            if ($psrMessage = $consumer->receive(1000)) {
+                if (false == $isTransportStarted) {
+                    $transport->start();
+                    $isTransportStarted = true;
+                }
+
+
+                $message = unserialize($psrMessage->getBody());
+
+                $count += $transport->send($message, $failedRecipients);
+
+                $consumer->acknowledge($psrMessage);
+            }
+
+            if ($this->getMessageLimit() && $count >= $this->getMessageLimit()) {
+                break;
+            }
+
+            if ($this->getTimeLimit() && (time() - $time) >= $this->getTimeLimit()) {
+                break;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return true;
+    }
+}

--- a/swiftmailer/composer.json
+++ b/swiftmailer/composer.json
@@ -1,0 +1,48 @@
+{
+    "require": {
+        "swiftmailer/swiftmailer": "^6.0",
+        "enqueue/fs": "*@dev",
+        "enqueue/enqueue": "*@dev"
+    },
+    "autoload": {
+        "psr-4": { "Demo\\Swiftmailer\\": "" }
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../dev/pkg/psr-queue"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/test"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/enqueue"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/null"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/stomp"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/fs"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/amqp-ext"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/enqueue-bundle"
+        },
+        {
+            "type": "path",
+            "url": "../dev/pkg/job-queue"
+        }
+    ]
+}

--- a/swiftmailer/consume.php
+++ b/swiftmailer/consume.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once __DIR__.'/vendor/autoload.php';
+
+$transport = new Swift_SpoolTransport(new \Demo\Swiftmailer\QueueSpool(
+    \Enqueue\dsn_to_context('file:/'.__DIR__.'/queue')
+));
+
+/** @var \Demo\Swiftmailer\QueueSpool $spool */
+$spool = $transport->getSpool();
+$spool->setTimeLimit(3);
+
+$realTransport = (new Swift_SmtpTransport('smtp.gmail.com', 465, 'ssl'))
+    ->setUsername(getenv('GUSER'))
+    ->setPassword(getenv('GPASS'))
+;
+
+$spool->flushQueue($realTransport);

--- a/swiftmailer/send.php
+++ b/swiftmailer/send.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once __DIR__.'/vendor/autoload.php';
+
+$transport = new Swift_SpoolTransport(new \Demo\Swiftmailer\QueueSpool(
+    \Enqueue\dsn_to_context('file:/'.__DIR__.'/queue')
+));
+
+$mailer = new Swift_Mailer($transport);
+
+$message = (new Swift_Message('Wonderful Subject'))
+    ->setFrom(['kotlyar.maksim@gmail.com' => 'Maksim'])
+    ->setTo(['kotlyar.maksim@gmail.com' => 'Maksim'])
+    ->setBody('Here is the message itself')
+;
+
+$result = $mailer->send($message);
+
+
+//$transport = (new Swift_SmtpTransport('smtp.gmail.com', 465, 'ssl'))
+//    ->setUsername(getenv('GUSER'))
+//    ->setPassword(getenv('GPASS'))
+//;


### PR DESCRIPTION
The PR shows how you can send emails to MQ first and then process them later in a consumer. 

To send to MQ run:

```bash
$GUSER=foo@gmail.com GPASS="yourGmailPass" php send.php
```

to send messages for real 


```bash
$GUSER=foo@gmail.com GPASS="yourGmailPass" php consume.php
```