### PR TITLE
Websocket over MQ. Chat demo.

### DIFF
--- a/Dockerfile.rabbitmq
+++ b/Dockerfile.rabbitmq
@@ -1,0 +1,13 @@
+FROM rabbitmq:3-management
+
+RUN apt-get update
+RUN apt-get install -y curl
+
+RUN curl http://www.rabbitmq.com/community-plugins/v3.6.x/rabbitmq_delayed_message_exchange-0.0.1.ez > $RABBITMQ_HOME/plugins/rabbitmq_delayed_message_exchange-0.0.1.ez
+RUN rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
+RUN rabbitmq-plugins enable --offline rabbitmq_stomp
+RUN rabbitmq-plugins enable --offline rabbitmq_web_stomp
+
+EXPOSE 61613
+EXPOSE 15674
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,10 @@ services:
       - "3307:3306"
 
   rabbitmq:
-    image: enqueue/rabbitmq:latest
+    build: { context: ., dockerfile: Dockerfile.rabbitmq }
     ports:
       - "15673:15672"
+      - "15674:15674"
     environment:
       - RABBITMQ_DEFAULT_USER=guest
       - RABBITMQ_DEFAULT_PASS=guest

--- a/symfony/app/Resources/views/websocket.html.twig
+++ b/symfony/app/Resources/views/websocket.html.twig
@@ -3,17 +3,13 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
 
         <script>
-            var ws = new WebSocket('ws://127.0.0.1:15674/ws');
-            var client = Stomp.over(ws);
+            var client = Stomp.over(new WebSocket('ws://127.0.0.1:15674/ws'));
 
-            // RabbitMQ SockJS does not support heart-beats
-            client.heartbeat.outgoing = 0;
-            client.heartbeat.incoming = 0;
             client.debug = onDebug;
             client.connect('guest', 'guest', onConnect, onError, 'mqs');
 
             function onConnect() {
-                var id = client.subscribe("/exchange/chat", function(d) {
+                client.subscribe("/exchange/chat", function(d) {
                     var node = document.createTextNode(d.body + '\n');
                     document.getElementById('chat').appendChild(node);
                 });

--- a/symfony/app/Resources/views/websocket.html.twig
+++ b/symfony/app/Resources/views/websocket.html.twig
@@ -1,0 +1,49 @@
+<html>
+    <head>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+
+        <script>
+            var ws = new WebSocket('ws://127.0.0.1:15674/ws');
+            var client = Stomp.over(ws);
+
+            // RabbitMQ SockJS does not support heart-beats
+            client.heartbeat.outgoing = 0;
+            client.heartbeat.incoming = 0;
+            client.debug = onDebug;
+            client.connect('guest', 'guest', onConnect, onError, 'mqs');
+
+            function onConnect() {
+                var id = client.subscribe("/exchange/chat", function(d) {
+                    var node = document.createTextNode(d.body + '\n');
+                    document.getElementById('chat').appendChild(node);
+                });
+
+                client.subscriptions['/temp-queue/chat_history'] = function(d) {
+                    document.getElementById('chat').innerText = d.body + '\n';
+                };
+
+                client.send('/queue/chat_request_history', { "reply-to": '/temp-queue/chat_history' }, '');
+            }
+
+            function onError(e) {
+                console.log("STOMP ERROR", e);
+            }
+
+            function onDebug(m) {
+                console.log("STOMP DEBUG", m);
+            }
+
+            function sendMsg() {
+                var msg = document.getElementById('msg').value;
+                client.send('/exchange/chat', { "content-type": "text/plain" }, msg.trim());
+            }
+        </script>
+    </head>
+    <body>
+        <h1>Web stomp chat</h1>
+        <input title="Message: " id="msg" type="text" />
+        <button id="send" onclick="sendMsg()">Send</button>
+        <br />
+        <pre id="chat"></pre>
+    </body>
+</html>

--- a/symfony/app/config/config.yml
+++ b/symfony/app/config/config.yml
@@ -165,6 +165,14 @@ services:
     tags:
         - { name: 'enqueue.client.processor' }
 
+  app.async.chat_history_processor:
+    class: 'AppBundle\Async\ChatHistoryProcessor'
+    arguments: ['%kernel.root_dir%/../var']
+
+  app.async.save_chat_history_processor:
+    class: 'AppBundle\Async\SaveChatHistoryProcessor'
+    arguments: ['%kernel.root_dir%/../var']
+
   app.async.upload_picture_processor:
     class: 'AppBundle\Async\UploadPictureProcessor'
     tags:

--- a/symfony/src/AppBundle/Async/ChatHistoryProcessor.php
+++ b/symfony/src/AppBundle/Async/ChatHistoryProcessor.php
@@ -1,0 +1,44 @@
+<?php
+namespace AppBundle\Async;
+
+use Enqueue\Consumption\QueueSubscriberInterface;
+use Enqueue\Consumption\Result;
+use Enqueue\Psr\PsrContext;
+use Enqueue\Psr\PsrMessage;
+use Enqueue\Psr\PsrProcessor;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ChatHistoryProcessor implements PsrProcessor, QueueSubscriberInterface
+{
+    /**
+     * @var
+     */
+    private $storeDir;
+
+    /**
+     * @param $storeDir
+     */
+    public function __construct($storeDir)
+    {
+        $this->storeDir = $storeDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(PsrMessage $message, PsrContext $context)
+    {
+        $fs = new Filesystem();
+        $fs->touch($this->storeDir.'/chat_history');
+
+        return Result::reply($context->createMessage(file_get_contents($this->storeDir.'/chat_history')));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedQueues()
+    {
+        return ['chat_request_history'];
+    }
+}

--- a/symfony/src/AppBundle/Async/SaveChatHistoryProcessor.php
+++ b/symfony/src/AppBundle/Async/SaveChatHistoryProcessor.php
@@ -1,0 +1,49 @@
+<?php
+namespace AppBundle\Async;
+
+use Enqueue\Consumption\QueueSubscriberInterface;
+use Enqueue\Psr\PsrContext;
+use Enqueue\Psr\PsrMessage;
+use Enqueue\Psr\PsrProcessor;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\LockHandler;
+
+class SaveChatHistoryProcessor implements PsrProcessor, QueueSubscriberInterface
+{
+    /**
+     * @var
+     */
+    private $storeDir;
+
+    /**
+     * @param $storeDir
+     */
+    public function __construct($storeDir)
+    {
+        $this->storeDir = $storeDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(PsrMessage $message, PsrContext $context)
+    {
+        $fs = new Filesystem();
+        $fs->touch($this->storeDir.'/chat_history');
+
+        $chatMessages = array_slice(file($this->storeDir.'/chat_history', FILE_IGNORE_NEW_LINES), -19, 19);
+        $chatMessages[] = trim($message->getBody());
+
+        file_put_contents($this->storeDir.'/chat_history', implode(PHP_EOL, $chatMessages));
+
+        return self::ACK;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedQueues()
+    {
+        return ['save_chat_history'];
+    }
+}

--- a/symfony/src/AppBundle/Controller/DefaultController.php
+++ b/symfony/src/AppBundle/Controller/DefaultController.php
@@ -24,13 +24,13 @@ class DefaultController extends Controller
         /** @var ProducerInterface $producer */
         $producer = $this->get('enqueue.producer');
 
-        $producer->send('foo_topic', 'Hello world');
+        $producer->sendEvent('foo_topic', 'Hello world');
 
-        $producer->send('bar_topic', ['bar' => 'val']);
+        $producer->sendEvent('bar_topic', ['bar' => 'val']);
 
         $message = new Message();
         $message->setBody('baz');
-        $producer->send('baz_topic', $message);
+        $producer->sendEvent('baz_topic', $message);
 
         // replace this example code with whatever you need
         return $this->render('default/index.html.twig', [
@@ -46,8 +46,8 @@ class DefaultController extends Controller
         /** @var ProducerInterface $producer */
         $producer = $this->get('enqueue.producer');
 
-        $producer->send(LiipImagineTopics::RESOLVE_CACHE, new ResolveCache('kitten.jpg'));
-        $producer->send(LiipImagineTopics::RESOLVE_CACHE, new ResolveCache('castle.jpg', ['thumbnail_223x223']));
+        $producer->sendEvent(LiipImagineTopics::RESOLVE_CACHE, new ResolveCache('kitten.jpg'));
+        $producer->sendEvent(LiipImagineTopics::RESOLVE_CACHE, new ResolveCache('castle.jpg', ['thumbnail_223x223']));
 
         return new Response(<<<HTML
 <p> The controller sends a message to resolve cache for two images kitten.jpg and castle.jpg.</p>

--- a/symfony/src/AppBundle/Controller/DefaultController.php
+++ b/symfony/src/AppBundle/Controller/DefaultController.php
@@ -95,4 +95,12 @@ HTML
 HTML
         );
     }
+
+    /**
+     * @Route("/websocket/chat-demo", name="websocket_chat_demo")
+     */
+    public function websocketChatDemoAction(Request $request)
+    {
+        return $this->render('::websocket.html.twig');
+    }
 }


### PR DESCRIPTION
This is inspired by this post: [RabbitMQ and WebSockets](https://www.cloudamqp.com/blog/2016-10-10-RabbitMQ-and-WebSockets.html). 

To play with it I built a real-time chat + a server side (PHP) that stores the messaging history. It is also possible to request the history, for example on page refresh. 

